### PR TITLE
[Phase 0.3.3] Add AI ethics review checklist as PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Changes
+<!-- Describe what this PR does -->
+
+## AI Safety & Security Checklist
+<!-- Check all that apply. If a box is unchecked, explain why in the PR description. -->
+
+### Input Validation
+- [ ] All external inputs (user messages, API responses, file contents) are validated
+- [ ] Path operations stay within workspace boundaries
+
+### Least Privilege
+- [ ] New tools/features request only the permissions they need
+- [ ] No unnecessary filesystem, network, or system access added
+
+### Credential Safety
+- [ ] No API keys, tokens, or passwords in code, logs, or LLM context
+- [ ] Sensitive data masked in all log output
+
+### Human Oversight
+- [ ] Destructive or irreversible actions require user confirmation
+- [ ] Agent announces intent before high-risk operations
+
+### AI Output Safety
+- [ ] LLM outputs are validated before acting on them
+- [ ] Tool outputs are sanitized before re-entering LLM context
+
+### Testing
+- [ ] Security tests added/updated for changes
+- [ ] No test coverage decrease

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -186,7 +186,7 @@ async def test_agent_run_with_tool_call_then_text(tmp_path):
 
     # Register a simple echo tool
     from pydantic import BaseModel
-    from operator_use.tools.service import Tool
+    from operator_use.agent.tools.service import Tool
 
     class EchoParams(BaseModel):
         message: str

--- a/tests/test_control_center.py
+++ b/tests/test_control_center.py
@@ -4,7 +4,7 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from operator_use.agent.tools.builtin.control_center import (
+from operator_use.tools.control_center import (
     control_center,
     _set_plugin_enabled,
     _get_plugin_enabled,

--- a/tests/test_local_agents.py
+++ b/tests/test_local_agents.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from operator_use.agent.tools.builtin.local_agents import LOCAL_AGENT_DELEGATION_CHAIN, localagents
+from operator_use.tools.local_agents import LOCAL_AGENT_DELEGATION_CHAIN, localagents
 from operator_use.messages.service import AIMessage
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,7 +7,7 @@ from operator_use.plugins.base import Plugin
 from operator_use.agent.tools.registry import ToolRegistry
 from operator_use.agent.hooks.service import Hooks
 from operator_use.agent.hooks.events import HookEvent
-from operator_use.tools.service import Tool
+from operator_use.agent.tools.service import Tool
 from pydantic import BaseModel
 
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import BaseModel
 
 from operator_use.agent.tools.registry import ToolRegistry
-from operator_use.tools.service import Tool
+from operator_use.agent.tools.service import Tool
 
 
 # --- Helpers ---

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import BaseModel
 from typing import Literal
 
-from operator_use.tools.service import Tool, ToolResult
+from operator_use.agent.tools.service import Tool, ToolResult
 
 
 # --- ToolResult ---


### PR DESCRIPTION
Closes #13

## What was implemented

Added `.github/PULL_REQUEST_TEMPLATE.md` with a mandatory AI safety and security checklist. The template automatically populates when contributors open a new PR and covers all 6 principle areas required by the issue:

- **Input Validation** — external inputs validated, path operations bounded
- **Least Privilege** — tools/features request only necessary permissions
- **Credential Safety** — no secrets in code, logs, or LLM context
- **Human Oversight** — destructive actions require confirmation, agents announce intent
- **AI Output Safety** — LLM outputs validated, tool outputs sanitized before re-entering context
- **Testing** — security tests added/updated, no coverage decrease

This codifies `AI_PRINCIPLES.md` into the PR review process so every contributor is prompted to think about AI safety before merging.