### PR TITLE
feat: macOS Agent Space — isolate agent windows to Space 2 [#29]

### DIFF
--- a/operator_use/computer/macos/agent_space.py
+++ b/operator_use/computer/macos/agent_space.py
@@ -1,0 +1,210 @@
+"""macOS Agent Space manager — isolate agent windows to Space 2.
+
+Subscribes to ``NSWorkspaceActiveSpaceDidChangeNotification`` so the manager
+is notified whenever the user switches Spaces.  When :py:meth:`move_to_agent_space`
+is called, the named application is moved to Space 2 via AppleScript, keeping
+the user's Space 1 free of agent windows.
+
+AppleScript approach (``key code 18 using {control down}``) is used instead of
+the private ``CGSMoveWindowsToManagedSpace`` API so the module has no private-
+framework dependency.
+
+Usage::
+
+    if sys.platform == "darwin":
+        manager = AgentSpaceManager()
+        manager.activate()
+        manager.move_to_agent_space("Safari")
+        ...
+        manager.deactivate()
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import threading
+from typing import Callable
+
+if sys.platform != "darwin":
+    raise ImportError("operator_use.computer.macos.agent_space is macOS-only")
+
+logger = logging.getLogger(__name__)
+
+# AppleScript that:
+#   1. Switches to Space 2 via Ctrl+2
+#   2. Activates the target application (bringing its windows to the current Space)
+#   3. Returns to Space 1 via Ctrl+1
+_MOVE_TO_SPACE2_SCRIPT = """\
+tell application "System Events"
+    key code 19 using {{control down}}
+    delay 0.4
+end tell
+tell application "{app_name}"
+    activate
+end tell
+delay 0.3
+tell application "System Events"
+    key code 18 using {{control down}}
+    delay 0.2
+end tell
+"""
+
+# AppleScript used when *not* returning to Space 1 (agent stays on Space 2).
+_SWITCH_TO_SPACE2_SCRIPT = """\
+tell application "System Events"
+    key code 19 using {{control down}}
+end tell
+delay 0.4
+tell application "{app_name}"
+    activate
+end tell
+"""
+
+
+class AgentSpaceManager:
+    """Manage a dedicated macOS Space (Space 2) for agent-opened windows.
+
+    Args:
+        on_space_change: Optional callback invoked each time
+            ``NSWorkspaceActiveSpaceDidChangeNotification`` fires.  Receives no
+            arguments; called on the notification thread.
+        return_to_user_space: When ``True`` (default), after moving an app to
+            Space 2 the manager switches back to Space 1 so the user's view is
+            undisturbed.
+    """
+
+    def __init__(
+        self,
+        on_space_change: Callable[[], None] | None = None,
+        return_to_user_space: bool = True,
+    ) -> None:
+        self._on_space_change = on_space_change
+        self._return_to_user_space = return_to_user_space
+        self._active = False
+        self._observer = None  # NSObject observer token
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def activate(self) -> None:
+        """Subscribe to Space-change notifications.
+
+        Safe to call multiple times; subsequent calls are no-ops.
+        """
+        with self._lock:
+            if self._active:
+                return
+            self._active = True
+
+        try:
+            from AppKit import NSWorkspace  # type: ignore[import]
+            from Foundation import NSNotificationCenter as _NSNotificationCenter  # type: ignore[import]  # noqa: F401
+
+            workspace = NSWorkspace.sharedWorkspace()
+            notification_center = workspace.notificationCenter()
+
+            self._observer = notification_center.addObserverForName_object_queue_usingBlock_(
+                "NSWorkspaceActiveSpaceDidChangeNotification",
+                None,
+                None,
+                self._handle_space_change,
+            )
+            logger.debug("AgentSpaceManager activated — subscribed to space-change notifications")
+        except ImportError:
+            logger.warning(
+                "AgentSpaceManager: pyobjc-framework-Cocoa not available — "
+                "space-change notifications disabled."
+            )
+
+    def deactivate(self) -> None:
+        """Unsubscribe from Space-change notifications.
+
+        Safe to call multiple times; subsequent calls are no-ops.
+        """
+        with self._lock:
+            if not self._active:
+                return
+            self._active = False
+
+        if self._observer is not None:
+            try:
+                from AppKit import NSWorkspace  # type: ignore[import]
+
+                workspace = NSWorkspace.sharedWorkspace()
+                notification_center = workspace.notificationCenter()
+                notification_center.removeObserver_(self._observer)
+                self._observer = None
+            except ImportError:
+                pass
+            except Exception:
+                logger.debug("AgentSpaceManager: failed to remove observer", exc_info=True)
+
+        logger.debug("AgentSpaceManager deactivated")
+
+    # ------------------------------------------------------------------
+    # Core operation
+    # ------------------------------------------------------------------
+
+    def move_to_agent_space(self, app_name: str) -> bool:
+        """Move *app_name* to Space 2 using AppleScript.
+
+        Args:
+            app_name: The display name of the application as it appears in the
+                Dock / Activity Monitor (e.g. ``"Safari"``, ``"Terminal"``).
+
+        Returns:
+            ``True`` if the AppleScript ran without error, ``False`` otherwise.
+        """
+        if self._return_to_user_space:
+            script = _MOVE_TO_SPACE2_SCRIPT.format(app_name=app_name)
+        else:
+            script = _SWITCH_TO_SPACE2_SCRIPT.format(app_name=app_name)
+
+        return self._run_applescript(script, context=f"move {app_name!r} to Space 2")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _handle_space_change(self, notification) -> None:  # noqa: ANN001
+        """Invoked by NSNotificationCenter on space transitions."""
+        logger.debug("AgentSpaceManager: active space changed")
+        if self._on_space_change:
+            try:
+                self._on_space_change()
+            except Exception:
+                logger.exception("AgentSpaceManager on_space_change callback raised")
+
+    @staticmethod
+    def _run_applescript(script: str, context: str = "") -> bool:
+        """Execute an AppleScript string via ``osascript`` and return success."""
+        try:
+            result = subprocess.run(
+                ["osascript", "-e", script],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    "AgentSpaceManager AppleScript failed [%s]: %s",
+                    context,
+                    result.stderr.strip(),
+                )
+                return False
+            return True
+        except FileNotFoundError:
+            logger.error("AgentSpaceManager: osascript not found — is this macOS?")
+            return False
+        except subprocess.TimeoutExpired:
+            logger.error("AgentSpaceManager: AppleScript timed out [%s]", context)
+            return False
+        except Exception:
+            logger.exception(
+                "AgentSpaceManager: unexpected error running AppleScript [%s]", context
+            )
+            return False

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -186,7 +186,7 @@ async def test_agent_run_with_tool_call_then_text(tmp_path):
 
     # Register a simple echo tool
     from pydantic import BaseModel
-    from operator_use.tools.service import Tool
+    from operator_use.agent.tools.service import Tool
 
     class EchoParams(BaseModel):
         message: str

--- a/tests/test_agent_space.py
+++ b/tests/test_agent_space.py
@@ -1,0 +1,287 @@
+"""Tests for operator_use.computer.macos.agent_space.
+
+The module is macOS-only; we patch ``sys.platform`` to ``"darwin"`` before
+importing so these tests run on any platform.  All Objective-C / AppKit calls
+are mocked.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import shim — patch sys.platform before the module is loaded.
+# ---------------------------------------------------------------------------
+
+
+def _import_agent_space():
+    """Import (or re-import) agent_space with sys.platform forced to 'darwin'."""
+    # Remove any cached version so the platform guard re-evaluates.
+    sys.modules.pop("operator_use.computer.macos.agent_space", None)
+
+    with patch.object(sys, "platform", "darwin"):
+        import importlib
+
+        mod = importlib.import_module("operator_use.computer.macos.agent_space")
+    return mod
+
+
+@pytest.fixture()
+def mod():
+    return _import_agent_space()
+
+
+@pytest.fixture()
+def manager(mod):
+    return mod.AgentSpaceManager()
+
+
+# ---------------------------------------------------------------------------
+# Import guard
+# ---------------------------------------------------------------------------
+
+
+class TestImportGuard:
+    def test_import_fails_on_non_darwin(self):
+        sys.modules.pop("operator_use.computer.macos.agent_space", None)
+        with patch.object(sys, "platform", "linux"):
+            with pytest.raises(ImportError):
+                import importlib
+
+                importlib.import_module("operator_use.computer.macos.agent_space")
+        sys.modules.pop("operator_use.computer.macos.agent_space", None)
+
+
+# ---------------------------------------------------------------------------
+# activate / deactivate
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def _make_appkit_mock(self):
+        """Return fake AppKit / Foundation modules."""
+        appkit = types.ModuleType("AppKit")
+        foundation = types.ModuleType("Foundation")
+
+        workspace = MagicMock()
+        notification_center = MagicMock()
+        workspace.notificationCenter.return_value = notification_center
+        appkit.NSWorkspace = MagicMock()
+        appkit.NSWorkspace.sharedWorkspace.return_value = workspace
+        foundation.NSNotificationCenter = MagicMock()
+
+        return appkit, foundation, notification_center
+
+    def test_activate_subscribes_to_notification(self, manager):
+        appkit, foundation, nc = self._make_appkit_mock()
+        with patch.dict("sys.modules", {"AppKit": appkit, "Foundation": foundation}):
+            manager.activate()
+
+        nc.addObserverForName_object_queue_usingBlock_.assert_called_once()
+        name_arg = nc.addObserverForName_object_queue_usingBlock_.call_args[0][0]
+        assert name_arg == "NSWorkspaceActiveSpaceDidChangeNotification"
+
+    def test_activate_idempotent(self, manager):
+        appkit, foundation, nc = self._make_appkit_mock()
+        with patch.dict("sys.modules", {"AppKit": appkit, "Foundation": foundation}):
+            manager.activate()
+            manager.activate()  # second call should be a no-op
+
+        assert nc.addObserverForName_object_queue_usingBlock_.call_count == 1
+
+    def test_deactivate_removes_observer(self, manager):
+        appkit, foundation, nc = self._make_appkit_mock()
+        observer_token = MagicMock()
+        nc.addObserverForName_object_queue_usingBlock_.return_value = observer_token
+
+        with patch.dict("sys.modules", {"AppKit": appkit, "Foundation": foundation}):
+            manager.activate()
+            manager.deactivate()
+
+        nc.removeObserver_.assert_called_once_with(observer_token)
+
+    def test_deactivate_idempotent(self, manager):
+        appkit, foundation, nc = self._make_appkit_mock()
+        with patch.dict("sys.modules", {"AppKit": appkit, "Foundation": foundation}):
+            manager.activate()
+            manager.deactivate()
+            manager.deactivate()  # second call should be a no-op
+
+        assert nc.removeObserver_.call_count == 1
+
+    def test_activate_without_appkit_logs_warning(self, manager, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            with patch.dict("sys.modules", {"AppKit": None, "Foundation": None}):
+                manager.activate()
+
+        # Should warn but not raise
+        assert manager._active is True  # flag still set
+
+    def test_deactivate_clears_active_flag(self, manager):
+        appkit, foundation, nc = self._make_appkit_mock()
+        with patch.dict("sys.modules", {"AppKit": appkit, "Foundation": foundation}):
+            manager.activate()
+        manager.deactivate()
+        assert manager._active is False
+
+
+# ---------------------------------------------------------------------------
+# move_to_agent_space
+# ---------------------------------------------------------------------------
+
+
+class TestMoveToAgentSpace:
+    def test_runs_applescript_for_named_app(self, manager):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            result = manager.move_to_agent_space("Safari")
+
+        assert result is True
+        assert mock_run.called
+        # The script passed to osascript should contain the app name
+        script_arg = mock_run.call_args[0][0]
+        assert "osascript" in script_arg
+        # The -e body should contain Safari
+        full_call = " ".join(str(a) for a in mock_run.call_args[0][0])
+        assert "Safari" in full_call or "Safari" in str(mock_run.call_args)
+
+    def test_returns_false_on_nonzero_exit(self, manager):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stderr="Error: No application named Nonexistent"
+            )
+            result = manager.move_to_agent_space("Nonexistent")
+
+        assert result is False
+
+    def test_returns_false_on_timeout(self, manager):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("osascript", 10)):
+            result = manager.move_to_agent_space("Terminal")
+
+        assert result is False
+
+    def test_returns_false_when_osascript_missing(self, manager):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = manager.move_to_agent_space("Terminal")
+
+        assert result is False
+
+    def test_script_contains_return_to_space1_when_enabled(self, manager):
+        """When return_to_user_space=True, the AppleScript should include Ctrl+1."""
+        assert manager._return_to_user_space is True
+        mod = _import_agent_space()
+        # key code 18 = Ctrl+1
+        assert "key code 18" in mod._MOVE_TO_SPACE2_SCRIPT
+
+    def test_script_no_return_when_disabled(self, mod):
+        manager = mod.AgentSpaceManager(return_to_user_space=False)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            manager.move_to_agent_space("Finder")
+
+        script_passed = mock_run.call_args[0][0][2]  # ['osascript', '-e', SCRIPT]
+        # The no-return script should NOT contain the switch-back key code 18
+        assert "key code 18" not in script_passed
+
+
+# ---------------------------------------------------------------------------
+# Space-change notification callback
+# ---------------------------------------------------------------------------
+
+
+class TestSpaceChangeCallback:
+    def test_on_space_change_called_on_notification(self, manager):
+        events = []
+        manager._on_space_change = lambda: events.append(1)
+        manager._handle_space_change(MagicMock())
+        assert len(events) == 1
+
+    def test_on_space_change_none_does_not_raise(self, manager):
+        manager._on_space_change = None
+        manager._handle_space_change(MagicMock())  # should not raise
+
+    def test_callback_exception_does_not_propagate(self, manager, caplog):
+        import logging
+
+        def _bad():
+            raise RuntimeError("oops")
+
+        manager._on_space_change = _bad
+        with caplog.at_level(logging.ERROR):
+            manager._handle_space_change(MagicMock())  # should not raise
+
+        assert any("callback" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _run_applescript static helper
+# ---------------------------------------------------------------------------
+
+
+class TestRunAppleScript:
+    def test_success(self, mod):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            result = mod.AgentSpaceManager._run_applescript('return "ok"')
+        assert result is True
+
+    def test_non_zero_returns_false(self, mod):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="error")
+            result = mod.AgentSpaceManager._run_applescript("bad script")
+        assert result is False
+
+    def test_timeout_returns_false(self, mod):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("osascript", 10)):
+            result = mod.AgentSpaceManager._run_applescript("slow script")
+        assert result is False
+
+    def test_file_not_found_returns_false(self, mod):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = mod.AgentSpaceManager._run_applescript("any script")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    def test_concurrent_activate_deactivate(self, mod):
+        appkit = types.ModuleType("AppKit")
+        foundation = types.ModuleType("Foundation")
+        workspace = MagicMock()
+        nc = MagicMock()
+        workspace.notificationCenter.return_value = nc
+        appkit.NSWorkspace = MagicMock()
+        appkit.NSWorkspace.sharedWorkspace.return_value = workspace
+        foundation.NSNotificationCenter = MagicMock()
+
+        manager = mod.AgentSpaceManager()
+        errors = []
+
+        def _worker():
+            try:
+                with patch.dict("sys.modules", {"AppKit": appkit, "Foundation": foundation}):
+                    for _ in range(10):
+                        manager.activate()
+                        manager.deactivate()
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_worker) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Thread-safety errors: {errors}"

--- a/tests/test_control_center.py
+++ b/tests/test_control_center.py
@@ -4,7 +4,7 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from operator_use.agent.tools.builtin.control_center import (
+from operator_use.tools.control_center import (
     control_center,
     _set_plugin_enabled,
     _get_plugin_enabled,

--- a/tests/test_local_agents.py
+++ b/tests/test_local_agents.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from operator_use.agent.tools.builtin.local_agents import LOCAL_AGENT_DELEGATION_CHAIN, localagents
+from operator_use.tools.local_agents import LOCAL_AGENT_DELEGATION_CHAIN, localagents
 from operator_use.messages.service import AIMessage
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,7 +7,7 @@ from operator_use.plugins.base import Plugin
 from operator_use.agent.tools.registry import ToolRegistry
 from operator_use.agent.hooks.service import Hooks
 from operator_use.agent.hooks.events import HookEvent
-from operator_use.tools.service import Tool
+from operator_use.agent.tools.service import Tool
 from pydantic import BaseModel
 
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import BaseModel
 
 from operator_use.agent.tools.registry import ToolRegistry
-from operator_use.tools.service import Tool
+from operator_use.agent.tools.service import Tool
 
 
 # --- Helpers ---

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import BaseModel
 from typing import Literal
 
-from operator_use.tools.service import Tool, ToolResult
+from operator_use.agent.tools.service import Tool, ToolResult
 
 
 # --- ToolResult ---


### PR DESCRIPTION
## Summary

Sub-component 3 of #29 (agent workspace isolation).

Adds `AgentSpaceManager` (macOS-only) that moves agent-opened application windows to Space 2 automatically, keeping the user's Space 1 free of agent activity.

- Subscribes to `NSWorkspaceActiveSpaceDidChangeNotification`
- Moves apps to Space 2 via AppleScript (no private API dependency)
- `activate()` / `deactivate()` lifecycle

Related: #29